### PR TITLE
chore(package): remove host flag from start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && tsc --noEmit",
-    "start": "node .output/server/index.mjs --host 0.0.0.0",
+    "start": "node .output/server/index.mjs",
     "drizzle:generate": "drizzle-kit generate",
     "drizzle:migrate": "drizzle-kit migrate",
     "drizzle:studio": "drizzle-kit studio --host 127.0.0.1"


### PR DESCRIPTION
Remove the explicit --host 0.0.0.0 flag from the start script in
package.json. The change simplifies the command used to run the
built server and avoids forcing the server to bind to all network
interfaces, which can be undesirable for local development or when
deployment environments manage host binding. This keeps the script
portable and relies on the runtime or deployment configuration to
control host binding.