### PR TITLE
fix(vite): remove start-storage-context from external lists

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,11 +12,11 @@ export default defineConfig({
   },
   ssr: {
     noExternal: ['@tanstack/start'],
-    external: ['node:async_hooks', '@tanstack/start-storage-context'],
+    external: ['node:async_hooks'],
   },
   build: {
     rollupOptions: {
-      external: ['node:async_hooks', '@tanstack/start-storage-context'],
+      external: ['node:async_hooks'],
     },
   },
   plugins: [


### PR DESCRIPTION
Remove '@tanstack/start-storage-context' from both SSR and Rollup 
external configurations in vite.config.ts. The change ensures the 
package is no longer treated as an external dependency, allowing Vite to
include and bundle it during SSR and build steps. This fixes runtime 
resolution issues
when the module must be bundled rather than referenced as an external.