### PR TITLE
fix(supabase): load Vite env from runtime when missing

### DIFF
--- a/src/lib/supabase.server.ts
+++ b/src/lib/supabase.server.ts
@@ -3,8 +3,9 @@ import { getRequest } from '@tanstack/react-start/server'
 import { createServerClient, type CookieMethodsServer } from '@supabase/ssr'
 import { parse as parseCookieHeader, serialize as serializeCookieHeader, type SerializeOptions } from 'cookie'
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL!
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY!
+// Check both import.meta.env (build-time) and process.env (runtime) for Vite variables
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || process.env.VITE_SUPABASE_URL
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   throw new Error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY')
 }


### PR DESCRIPTION
Allow Supabase URL and anon key to be read from process.env at runtime
in addition to import.meta.env build-time variables. This ensures the
server can initialize in environments where Vite injects variables at
runtime or when values are provided via process.env (e.g. Docker or
server-side deployments). Keep the existing runtime check and error if
neither source provides the required variables.